### PR TITLE
Issue#21 Accessibility fixes according to Firefox a11y report

### DIFF
--- a/Frontend/client/public/index.html
+++ b/Frontend/client/public/index.html
@@ -85,17 +85,15 @@
                                 <label for="movieSearch" id="searchLabel" class="visually-hidden">Search for movies</label>
                                 <input
                                     class="form-control"
-                                    type="search"
+                                    type="text"
                                     placeholder="Search movies..."
-                                    aria-label="Search movies"
                                     id="movieSearch"
                                     name="movieSearch"
                                     required
                                     minlength="2"
                                     autocomplete="off">
-                                <button class="btn btn-outline-success" type="submit" id="searchButton" disabled>
+                                <button class="btn btn-outline-success" type="submit" id="searchButton" aria-label="Search" disabled>
                                     <i class="fas fa-search" aria-hidden="true"></i>
-                                    <span class="visually-hidden">Search</span>
                                 </button>
                             </div>
                         </form>
@@ -140,6 +138,7 @@
     <main>
         <section id="filter-section">
             <h2>Filter Movies</h2>
+            <label for="genre-filter" class="visually-hidden">Genre filter</label>
             <select id="genre-filter">
                 <option value="">All Genres</option>
                 <option value="action">Action</option>
@@ -157,15 +156,18 @@
                 <option value="biography">Biography</option>
                 <option value="historical">Historical</option>
             </select>
+            <label for="year-filter" class="visually-hidden">Year filter</label>
             <select id="year-filter">
                 <option value="">All Years</option>
                 <!-- Options will be populated dynamically -->
             </select>
+            <label for="sort-order" class="visually-hidden">Sorting</label>
             <select id="sort-order">
                 <option value="title">Title</option>
                 <option value="year">Year</option>
                 <option value="runtime">Runtime</option>
             </select>
+            <label for="rating-filter" class="visually-hidden">Rating filter</label>
             <select id="rating-filter">
                 <option value="">All Ratings</option>
                 <option value="G">G</option>
@@ -174,11 +176,13 @@
                 <option value="R">R</option>
                 <option value="NC-17">NC-17</option>
             </select>
+            <label for="director-filter" class="visually-hidden">Directors filter</label>
             <select id="director-filter">
                 <option value="">All Directors</option>
                 <!-- Options will be populated dynamically -->
             </select>
-            <select id="cast-member-filter">
+            <label for="cast-member-filter" class="visually-hidden">Cast members filter</label>
+            <select id="cast-member-filter" aria-label="Cast members">
                 <option value="">All Cast Members</option>
                 <!-- Options will be populated dynamically -->
             </select>
@@ -193,7 +197,7 @@
                               data-bs-target="#addMovieModal" aria-label="Add new movie">
                           <i class="fas fa-plus" aria-hidden="true"></i> Add Movie
                       </button>
-                      <button class="btn btn-outline-primary" type="button" id="layout-toggle" 
+                      <button class="btn btn-outline-primary text-white border-0" type="button" id="layout-toggle" 
                               aria-label="Toggle view layout">
                           <i class="fas fa-list-ul" aria-hidden="true"></i>
                           <span>List View</span>
@@ -202,7 +206,7 @@
               </div>
           </div>
           
-          <div id="movie-table" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-4">
+          <div id="movie-table" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 g-4" role="presentation">
               <!-- Movies will be dynamically inserted here -->
           </div>
 
@@ -215,7 +219,7 @@
             <div class="row">
                 <div class="col-md-4">
                     <a href="/" class="text-body text-decoration-none">
-                        <img src="assets/logos/logo.svg" alt="" width="30" height="24" class="d-inline-block align-text-top">
+                        <img src="assets/logos/logo.svg" alt="FlickPicker Logo" width="30" height="24" class="d-inline-block align-text-top">
                     </a>
                     <small class="d-block mt-2">&copy; 2024 MovieNight. All rights reserved.</small>
                 </div>

--- a/Frontend/client/public/movies.mjs
+++ b/Frontend/client/public/movies.mjs
@@ -103,18 +103,18 @@ function createMovieCardHTML(movie) {
                 <div class="card-footer">
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="btn-group">
-                            <button type="button" class="btn btn-sm btn-outline-primary vote-btn" 
+                            <button type="button" class="btn btn-sm btn-outline-primary text-light" 
                                     data-vote="up" ${state.currentUser ? '' : 'disabled'}>
                                 <i class="fas fa-thumbs-up"></i> 
                                 <span class="vote-count">${movie.voteCount || 0}</span>
                             </button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" 
+                            <button type="button" class="btn btn-sm btn-outline-primary text-light" 
                                     onclick="showMovieDetails('${movie.id}')">
                                 <i class="fas fa-info-circle"></i> Details
                             </button>
                         </div>
                         <button type="button" 
-                            class="btn btn-sm btn-primary add-to-playlist-btn" 
+                            class="btn btn-sm btn-outline-primary add-to-playlist-btn text-light" 
                             onclick="addToPlaylist(${movie.id}, '${movie.title}', '${movie.imageUrl}')"
                             ${state.currentUser ? '' : 'disabled'}>
                             <i class="fas fa-plus"></i> Add to Playlist

--- a/Frontend/client/public/styles.css
+++ b/Frontend/client/public/styles.css
@@ -104,6 +104,11 @@ header, nav {
   white-space: nowrap;
 }
 
+.btn-outline-success:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
 /* ================================
  Main Content
 ================================= */
@@ -118,6 +123,12 @@ main {
 ================================= */
 #movie-table {
   padding-top: 0.5rem;
+  pointer-events: none;
+}
+
+#movie-table .card,
+#movie-table button {
+  pointer-events: auto;
 }
 
 .movies-header {
@@ -147,6 +158,12 @@ main {
   height: 18.75rem;
   object-fit: cover;
   width: 100%;
+}
+
+.vote-btn:disabled,
+.add-to-playlist-btn:disabled {
+  cursor: default;
+  pointer-events: none;
 }
 
 /* ================================


### PR DESCRIPTION
Summary #21 

This PR improves accessibility and color contrast for interactive elements in the movie grid to ensure compliance with WCAG standards and better usability on dark backgrounds, according to the Firefox accessibility report.

List of changes:

- Removed cursor: pointer from disabled elements.
- Adjusted text color for better contrast: replaced multiple instances of low-contrast blue on dark backgrounds with white, to meet W3C standards.
- Made the search input properly focusable.
- Added aria-label attributes to <select> filters (instead of visible <label>s) to preserve the current design.
- Changed <input type="search"> to <input type="text"> to work around a known Firefox accessibility bug.
- Added role="presentation" to the card grid wrapper to clarify non-interactive semantics.
- Added alt attribute to the footer logo image for screen readers.
- Minor design changes that change elements contrast.

<img width="1553" alt="Screenshot 2025-05-27 at 20 16 59" src="https://github.com/user-attachments/assets/7b6aea7d-b84e-4892-bfdd-cde813e789b0" />

Accessibility improvements should continue in future iterations. This PR addresses key issues, but achieving full WCAG compliance will require ongoing attention and refinement.

No accessibility issues in Firefox.


Note: I don’t have collaborator access to this repository, so I’m unable to assign reviewers, labels, or tasks directly.
Kindly help with assigning this PR to me and adding appropriate labels/reviewers.
Suggested reviewers: @itswael @gbowne1 @rconjoe @siferot