### PR TITLE
Fix manifest.json file so that it has proper start_url scope and id

### DIFF
--- a/Frontend/client/public/manifest.json
+++ b/Frontend/client/public/manifest.json
@@ -3,13 +3,13 @@
     "short_name": "FlickPicker",
     "dir": "ltr",
     "lang": "en",
-    "start_url": "http://127.0.0.1:5501/Frontend/client/public/index.html",
+    "start_url": "/",
     "display": "browser",
     "orientation": "any",
     "theme_color": "#4a90e2",
     "background_color": "#ffffff",
-    "scope": "http://127.0.0.1:5501/Frontend/client/public/",
-    "id": "http://127.0.0.1:5501/Frontend/client/public/index.html",
+    "scope": "/",
+    "id": "/",
     "icons":
     [
         {


### PR DESCRIPTION
This PR fixes #48 Where the manifest.json file was causing errors in the Firefox browser console Application tab.

Changed short_url, id and scope to '/' and it now does not error.

It also loads properly and gives a 200 and does not 404.