### PR TITLE
Fix issue #73: correct login button height problems on viewport < 450px

### DIFF
--- a/Frontend/client/public/index.html
+++ b/Frontend/client/public/index.html
@@ -104,7 +104,7 @@
                         </button>
                         <!-- Authentication Buttons -->
                         <div id="auth-buttons">
-                            <button class="btn btn-outline-contrast" type="button" data-bs-toggle="modal"
+                            <button class="btn btn-outline-contrast text-nowrap" type="button" data-bs-toggle="modal"
                                 data-bs-target="#loginModal" id="loginButton">
                                 <i class="fas fa-user" aria-hidden="true"></i>
                                 <span>Login</span>


### PR DESCRIPTION
**[Bug] Login button misaligned at screen widths < 450px #73** 

The problem was that the text inside the button was wrapping and adjusting to the "paragraph-like" structure of the text inside when forced to be shrinked.

I included Bootstrap's `text-nowrap` class to it to prevent the text inside the button to wrap.

Feel free to review and test accordingly.